### PR TITLE
Make error reporting thread safe

### DIFF
--- a/solocator/core/utils.py
+++ b/solocator/core/utils.py
@@ -3,7 +3,7 @@
 /***************************************************************************
 
  QGIS Solothurn Locator Plugin
- Copyright (C) 2019 Denis Rouzaud
+ Copyright (C) 2019 Denis Rouzaud, OPENGIS.ch
 
  ***************************************************************************/
 
@@ -19,15 +19,23 @@
 
 from qgis.core import Qgis, QgsMessageLog
 from qgis.utils import iface
+from PyQt5.QtCore import Qt, Q_ARG
 
 DEBUG = True
 
 
 def info(message: str, level: Qgis.MessageLevel = Qgis.Info):
-    QgsMessageLog.logMessage("{}: {}".format('SoLocator', message), "Locator bar", level)
-    iface.messageBar().pushMessage('SoLocator', message, level)
-
+    QgsMessageLog.logMessage("{}: {}".format(
+        'SoLocator', message), "Locator bar", level)
+    meta = iface.messageBar().metaObject()
+    if level == Qgis.Warning:
+        meta.invokeMethod(iface.messageBar(), 'pushWarning', Qt.QueuedConnection, Q_ARG("QString", 'SoLocator'), Q_ARG("QString", message))
+    elif level == Qgis.Critical:
+        meta.invokeMethod(iface.messageBar(), 'pushCritical', Qt.QueuedConnection, Q_ARG("QString", 'SoLocator'), Q_ARG("QString", message))
+    else:
+        meta.invokeMethod(iface.messageBar(), 'pushInfo', Qt.QueuedConnection, Q_ARG("QString", 'SoLocator'), Q_ARG("QString", message))
 
 def dbg_info(message: str):
     if DEBUG:
-        QgsMessageLog.logMessage("{}: {}".format('SoLocator', message), "Locator bar", Qgis.Info)
+        QgsMessageLog.logMessage("{}: {}".format(
+            'SoLocator', message), "Locator bar", Qgis.Info)


### PR DESCRIPTION
If errors happen on a background thread, they cannot directly be raised
to the message bar, since the message bar lives in the main thread.

They are now posted to the event queue of the main thread, so QGIS
will show information in the message bar instead of crashing.