### PR TITLE
Reestablish order of groups by defining a group score

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   release:
-    types: published
+    types: [published]
 
 jobs:
   release:
@@ -17,10 +17,10 @@ jobs:
         git submodule update --init --recursive
         sed -i 's#https://github.com/#git@github.com:#' .gitmodules
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     - name: Install qgis-plugin-ci
       run: pip3 install qgis-plugin-ci

--- a/solocator/core/solocator_filter.py
+++ b/solocator/core/solocator_filter.py
@@ -218,9 +218,11 @@ class SoLocatorFilter(QgsLocatorFilter):
         result.displayString = '{prefix}{title}'.format(prefix=' ↳ ' if sub_layer else '', title=data['display'])
         if stacktype == 'background':
             result.group = 'Hintergrundkarten'
+            result.groupScore = 0.7
         else:
             loading_mode: LoadingMode = self.settings.value('default_layer_loading_mode')
             result.group = 'Vordergrundkarten (Doppelklick: {normal}, Ctrl-Doppelklick: {alt})'.format(normal=loading_mode, alt=loading_mode.alternate_mode())
+            result.groupScore = 0.8
         result.userData = DataProductResult(
             type=data['type'],
             dataproduct_id=data['dataproduct_id'],
@@ -256,6 +258,7 @@ class SoLocatorFilter(QgsLocatorFilter):
                     result = QgsLocatorResult()
                     result.filter = self
                     result.group = 'Suche verfeinern'
+                    result.groupScore = 1
                     result.displayString = _filter['filterword']
                     if _filter['count']:
                         result.displayString += ' ({})'.format(_filter['count'])
@@ -277,6 +280,7 @@ class SoLocatorFilter(QgsLocatorFilter):
                     # dbg_info("feature: {}".format(f))
                     result.displayString = f['display']
                     result.group = 'Orte'
+                    result.groupScore = 0.9
                     result.userData = FeatureResult(
                         dataproduct_id=f['dataproduct_id'],
                         id_field_name=f['id_field_name'],


### PR DESCRIPTION
In QGIS 3.40, a `groupScore` for search results was introduced (https://github.com/qgis/QGIS/pull/58542). If this group score is missing, groups are sorted alphabetically.
Before, groups were sorted in the order in which they were added to the locator.

SoLocator group order before QGIS 3.40:
1. Suche verfeinern
2. Orte
3. Vordergrundkarten
4. Hintergrundkarten

Now, without a group score:
1. Hintergrundkarten
2. Orte
3. Suche verfeinern
4. Vordergrundkarten

This fix introduces a group score so that the original order is reestablished.


Please note that there is currently an issue in QGIS 3.42 /3.40 LTS, where the locator ignores all search scores and does not sort any items correctly. This bug has been fixed in the meantime: https://github.com/qgis/QGIS/pull/62043