### PR TITLE
Style file (*.qml) can't be applied to layers

### DIFF
--- a/solocator/core/layer.py
+++ b/solocator/core/layer.py
@@ -108,8 +108,8 @@ class SoLayer:
                 if layer.isValid() and self.qml:
                     with NamedTemporaryFile(mode='w', suffix='.qml', delete=False, encoding='utf-8') as fh:
                         fh.write(self.qml)
-                        msg, ok = layer.loadNamedStyle(fh.name)
                         fh.close()
+                        msg, ok = layer.loadNamedStyle(fh.name)
                         if not ok:
                             info(
                                 'SoLocator could not load QML style for layer {ln}. {emsg} URI: {uri}'


### PR DESCRIPTION
Customer reports that for certain vector layers, the *.qml style file can't be applied when adding the layer to the map. The layers receive a default style instead.

<img width="1253" height="830" alt="Screenshot from 2025-09-30 15-26-11" src="https://github.com/user-attachments/assets/6e6408ad-db40-4c9c-8467-8f16be682faa" />


Error message: 
> WARNING    SoLocator : SoLocator could not load QML style for layer  Synoptische IK Überschwemmung 0 - 30 Jahre (Naturgefahren). unexpected end of file in Zeile 1, Spalte 1 URI: service='pub' authcfg=sogis00 key='t_id' srid=2056 type=MultiPolygon table="afu_naturgefahren_pub_v2"."synoptische_intensitaet_ueberschwemmung_30_v" (geometrie)

Affected layers:
- Synoptische IK Überschwemmung 0 - 30 Jahre (Naturgefahren)
- Synoptische IK Überschwemmung 30 - 100 Jahre (Naturgefahren)
- Neozoen – Asiatische Hornisse – Nester

Not clear if any other layers are affected, couldn't find any more

Note:
- The style files aren't broken or deprecated. If the style file is saved to disk it can be applied to the vector layer
- The temporary file appears in the Windows temp folder and isn't empty, so the writing-to-disk is successful

Fix:
If the file is flushed or closed right after writing its content (`file.flush()` or `file.close()`), the subsequent `layer.loadNamedStyle()` is successful.

This fix does not explain why the error only appears for certain style files and not for others.

With fix applied:
<img width="1253" height="830" alt="Screenshot from 2025-09-30 15-27-18" src="https://github.com/user-attachments/assets/8c4fb0a7-96e8-4c5b-9df2-823b911fa71b" />


https://app.clickup.com/t/2192114/DEV-8325